### PR TITLE
Disable auto-shutdown after repeated power-on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ loopCmd=()
 # This is checked during updates to determine whether config should be patched. Do NOT modify.
 
 # shutdown_capacity (sc) #
-# When the battery is discharging and its capacity <= sc, acc daemon turns the phone off to reduce the discharge rate and protect the battery from potential damage induced by voltages below the operating range.
+# When the battery is discharging and its capacity <= sc and phone has been running for 15 minutes or more, acc daemon turns the phone off to reduce the discharge rate and protect the battery from potential damage induced by voltages below the operating range.
 # On capacity <= shutdown_capacity + 5, accd enables Android battery saver, triggers 5 vibrations once - and again on each subsequent capacity drop.
 
 # cooldown_capacity (cc) #
@@ -1134,6 +1134,9 @@ A common workaround is having `resume_capacity = pause_capacity - 1`. e.g., resu
 
 ---
 ## LATEST CHANGES
+
+**v2020.8.24 (202008240)**
+- Prevent phone off according to `shutdown_capacity`, if phone was power-on less than 15 minutes ago.
 
 **v2020.8.6 (202008060)**
 - Adaptive --info and --print (config) outputs

--- a/acc/accd.sh
+++ b/acc/accd.sh
@@ -252,7 +252,9 @@ if [ -f $TMPDIR/.config-ver ] && ! $init; then ###
           unset i c
 
           # auto-shutdown if battery is not charging and capacity is less than <shutdown_capacity>
-          ! test $(cat $batt/capacity) -le ${capacity[0]} || {
+          #   and system uptime 15 minutes or more
+          test $(cut -d '.' -f 1 /proc/uptime) -lt 900 \
+          || ! test $(cat $batt/capacity) -le ${capacity[0]} || {
             sleep ${loopDelay[1]}
             ! not_charging \
               || am start -n android/com.android.internal.app.ShutdownActivity < /dev/null > /dev/null 2>&1 \

--- a/acc/default-config.txt
+++ b/acc/default-config.txt
@@ -185,7 +185,7 @@ loopCmd=()
 # This is checked during updates to determine whether config should be patched. Do NOT modify.
 
 # shutdown_capacity (sc) #
-# When the battery is discharging and its capacity <= sc, acc daemon turns the phone off to reduce the discharge rate and protect the battery from potential damage induced by voltages below the operating range.
+# When the battery is discharging and its capacity <= sc and phone has been running for 15 minutes or more, acc daemon turns the phone off to reduce the discharge rate and protect the battery from potential damage induced by voltages below the operating range.
 # On capacity <= shutdown_capacity + 5, accd enables Android battery saver, triggers 5 vibrations once - and again on each subsequent capacity drop.
 
 # cooldown_capacity (cc) #

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=acc
 name=Advanced Charging Controller (ACC)
-version=v2020.8.6
-versionCode=202008060
+version=v2020.8.24
+versionCode=202008240
 author=VR25
 description=ACC is an Android software. It's primarily intended for extending battery service life. In a nutshell, this is achieved through limiting charging current, temperature and voltage. Any root solution is supported. The installation is always "systemless", whether or not the system is rooted with Magisk. If you're reading this from Magisk Manager > Downloads, tap here to open the documentation. Once there, if you're lazy, jump to the quick start section.


### PR DESCRIPTION
**v2020.8.24 (202008240)**
- Prevent phone off according to `shutdown_capacity`, if phone was power-on less than 15 minutes ago.

Fixes VR-25/acc#57