### PR TITLE
Fixed bug with handling `-u|--upgrade` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,9 @@ A common workaround is having `resume_capacity = pause_capacity - 1`. e.g., resu
 ---
 ## LATEST CHANGES
 
+**v2020.9.01 (202009010)**
+- Fixed bug with handling `-u|--upgrade` option.
+
 **v2020.8.24 (202008240)**
 - Prevent phone off according to `shutdown_capacity`, if phone was power-on less than 15 minutes ago.
 

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=acc
 name=Advanced Charging Controller (ACC)
-version=v2020.8.24
-versionCode=202008240
+version=v2020.9.01
+versionCode=202009010
 author=VR25
 description=ACC is an Android software. It's primarily intended for extending battery service life. In a nutshell, this is achieved through limiting charging current, temperature and voltage. Any root solution is supported. The installation is always "systemless", whether or not the system is rooted with Magisk. If you're reading this from Magisk Manager > Downloads, tap here to open the documentation. Once there, if you're lazy, jump to the quick start section.


### PR DESCRIPTION
Valid options passes as is, only last parameter (not valid option) uses as version for download, ignores other.

Fixes VR-25/acc#60