### PR TITLE
Fixed start on boot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,6 @@ Release Notes
 - Use `cmd` in place of most `dumpsys` calls.
 
 
-**v2020.10.9 (202010090)**
+**v2020.10.11 (202010110)**
 
 - Fixed start on boot.

--- a/README.md
+++ b/README.md
@@ -1072,3 +1072,8 @@ Release Notes
 - Move persistent data to /sdcard/Documents/vr25/acc/ for compatibility with Android 11 storage isolation.
 - Updated documentation (FAQ, tips, voltage issues, Samsung's "70% problem", etc.).
 - Use `cmd` in place of most `dumpsys` calls.
+
+
+**v2020.10.9 (202010090)**
+
+- Fixed start on boot.

--- a/acc/accd.sh
+++ b/acc/accd.sh
@@ -6,10 +6,15 @@
 # devs: triple hashtags (###) mark non-generic code
 
 
-# wait until the system is ready and data is decrypted
+# wait until the system is ready
+until [ .$(getprop sys.boot_completed) = .1 ]
+do
+  sleep 30
+done
+
+# wait until the data is decrypted
 pgrep zygote > /dev/null && {
-  until [ -d /sdcard/Download ] \
-    && [ .$(getprop sys.boot_completed) = .1 ]
+  until (cd /sdcard)
   do
     sleep 30
   done

--- a/acc/accd.sh
+++ b/acc/accd.sh
@@ -6,15 +6,13 @@
 # devs: triple hashtags (###) mark non-generic code
 
 
-# wait until the system is ready
-until [ .$(getprop sys.boot_completed) = .1 ]
+# wait until the data is decrypted and system is ready
+until [ -d /sdcard/Download ]
 do
   sleep 30
 done
-
-# wait until the data is decrypted
 pgrep zygote > /dev/null && {
-  until (cd /sdcard)
+  until [ .$(getprop sys.boot_completed) = .1 ]
   do
     sleep 30
   done

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=acc
 name=Advanced Charging Controller (ACC)
-version=v2020.10.8
-versionCode=202010080
+version=v2020.10.9
+versionCode=202010090
 author=VR25
 description=ACC is an Android software mainly intended for extending battery service life. In a nutshell, this is achieved through limiting charging current, temperature and voltage. Any root solution is supported. The installation is always "systemless", whether or not the system is rooted with Magisk. If you're reading this from Magisk Manager > Downloads, tap here to open the documentation. Once there, if you feel lazy, scroll down to the quick start section.

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=acc
 name=Advanced Charging Controller (ACC)
-version=v2020.10.9
-versionCode=202010090
+version=v2020.10.11
+versionCode=202010110
 author=VR25
 description=ACC is an Android software mainly intended for extending battery service life. In a nutshell, this is achieved through limiting charging current, temperature and voltage. Any root solution is supported. The installation is always "systemless", whether or not the system is rooted with Magisk. If you're reading this from Magisk Manager > Downloads, tap here to open the documentation. Once there, if you feel lazy, scroll down to the quick start section.


### PR DESCRIPTION
- On some devices the `zygote` process starts later than check occurred, so one needs to wait `boot_completed`.
- Used `cd` instead of `test -d` for check access into directory. A subdirectory may be checked later, if necessary, and this check may be processed without exit.

Updates #72 