### PR TITLE
prep for external editor app support

### DIFF
--- a/install/acc.sh
+++ b/install/acc.sh
@@ -97,6 +97,16 @@ daemon_ctrl() {
 
 
 edit() {
+  ext_app() {
+    case $1 in
+      e) ACT=EDIT; print_ext_app e ;;
+      v) ACT=VIEW; print_ext_app v ;;
+    esac
+    sleep 2.5
+    am start -a android.intent.action.$ACT \
+             -t 'text/plain' \
+             -d file://$2 &>/dev/null
+  }
   local file="$1"
   shift
   if [ -n "${1-}" ]; then
@@ -106,6 +116,9 @@ edit() {
       echo "$@" >> $file
     elif [ "$1" = d ]; then
       sed -Ei "\#$2#d" $file
+    elif [ "$1" = app ]; then
+      shift
+      ext_app e $file
     else
       IFS="$(printf ' \t\n')" eval "$* $file"
     fi
@@ -115,8 +128,10 @@ edit() {
         *.txt)
           if which nano > /dev/null; then
             print_quit CTRL-X
-          else
+          elif which vim vi > /dev/null; then
             print_quit "[esc] :q! [enter]" "[esc] :wq [enter]"
+          else
+            print_ext_app e
           fi
         ;;
         *.log|*.md|*.help)
@@ -128,7 +143,7 @@ edit() {
     }
     case $file in
      *.log|*.md|*.help) less $file;;
-     *) nano -$ $file || vim $file || vi $file;;
+     *) nano -$ $file || vim $file || vi $file || ext_app e $file ;;
     esac 2>/dev/null
   fi
 }

--- a/install/strings.sh
+++ b/install/strings.sh
@@ -76,6 +76,19 @@ print_not_found() {
   echo "$1 not found"
 }
 
+print_ext_app() {
+  case $1 in
+    e) act=editor ;;
+    v) act=viewer ;;
+  esac
+  cat << EOF
+  Opening external text $act app choosing
+  dialog and select any root-compatible
+  text $act app.
+ 
+  e.g., MiXplorer, QuickEdit, etc.
+EOF
+}
 
 print_help() {
   cat << EOF


### PR DESCRIPTION
```
usages:
 > acc -c|-l|-r app

todo:
 - proper ACTION_VIEW support for log/md files
 - update string in language files
```
